### PR TITLE
Add database observability: ES healthcheck and DB log capture

### DIFF
--- a/LOGGING.md
+++ b/LOGGING.md
@@ -17,6 +17,35 @@ make logs-today  # View today's logs
 make logs-errors # View errors only
 ```
 
+## Database Logs
+
+Database logs (postgres, elasticsearch) are captured separately from application logs.
+
+```bash
+# Start database services (auto-starts DB log capture + waits for healthy)
+make updb
+
+# View database errors (includes OOM detection)
+make dblogs-errors
+
+# Check today's DB logs
+make dblogs-today
+```
+
+### Database Log Commands
+
+| Command | Description |
+|---------|-------------|
+| `make dblogs` | View live DB logs (follow mode) |
+| `make dblogs-today` | View today's captured DB logs |
+| `make dblogs-errors` | Show errors including OOM/killed |
+| `make dblogs-service SERVICE=elasticsearch` | Filter to specific DB |
+| `make dblogs-search PATTERN='text'` | Search DB logs |
+| `make dblogs-start` | Manually start DB log capture |
+| `make dblogs-stop` | Stop DB log capture |
+| `make dblogs-status` | Show DB log disk usage |
+| `make dblogs-rotate` | Rotate DB logs |
+
 ## How It Works
 
 When you run `make up`, two things happen:
@@ -82,14 +111,17 @@ req-router-1    | 2026-01-09 14:30:01 ERROR Upstream service error
 ### Standard Startup
 
 ```bash
-# 1. Start databases (wait for healthy)
+# 1. Start databases (waits for healthy + auto-starts DB log capture)
 make updb
-make dblogs      # Watch until healthy, then Ctrl+C
+# No need to watch dblogs anymore - updb waits for health!
 
-# 2. Start application (auto-starts log capture)
+# 2. Start application (auto-starts app log capture)
 make up
 
-# 3. View live logs if needed
+# 3. Check for any DB errors if needed
+make dblogs-errors
+
+# 4. View live logs if needed
 make logs        # Ctrl+C to exit (capture continues in background)
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ updb: dbdirs ensurenetworks dblogdirs
 	docker compose -f db-docker-compose.yml down --remove-orphans
 	docker compose -f db-docker-compose.yml up -d
 	@echo "Waiting for databases to be healthy..."
-	@sleep 2
+	@sleep 5
 	@echo "  Postgres: checking pg_isready..."
 	@i=0; while [ $$i -lt 30 ]; do \
 		if docker compose -f db-docker-compose.yml exec -T postgres pg_isready -U postgres >/dev/null 2>&1; then \

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,11 @@ DATE_SUFFIX=${shell date +"%Y%m%d%H%M%S"}
 DATAROOT=.
 LOG_DIR=./logs
 LOG_PID_FILE=./logs/.capture.pid
+DBLOG_DIR=./dblogs
+DBLOG_PID_FILE=./dblogs/.capture.pid
 
 .PHONY: logs logs-start logs-stop logs-today logs-errors logs-service logs-search logs-rotate logs-status logs-clean logs-cron-install logs-cron-remove logdirs
+.PHONY: dblogs dblogs-start dblogs-stop dblogs-today dblogs-errors dblogs-service dblogs-search dblogs-rotate dblogs-status dblogs-clean dblogs-cron-install dblogs-cron-remove dblogdirs
 .PHONY: version version-history version-pull version-set rollback rollback-service rollback-to update-safe check-updates ecr-login migrate-versions
 
 encrypt:
@@ -74,6 +77,77 @@ logs-cron-remove:
 	@crontab -l 2>/dev/null | grep -v "dkapp.*logs-rotate" | crontab - && \
 	echo "Cron job removed"
 
+# ==============================================
+# DATABASE LOG MANAGEMENT
+# ==============================================
+
+dblogdirs:
+	@mkdir -p $(DBLOG_DIR)
+
+dblogs-start: dblogdirs
+	@if [ -f $(DBLOG_PID_FILE) ] && kill -0 $$(cat $(DBLOG_PID_FILE)) 2>/dev/null; then \
+		echo "DB log capture already running (PID: $$(cat $(DBLOG_PID_FILE)))"; \
+	else \
+		echo "Starting background DB log capture to $(DBLOG_DIR)/$$(date +%Y-%m-%d).log"; \
+		nohup docker compose -f db-docker-compose.yml logs -f >> $(DBLOG_DIR)/$$(date +%Y-%m-%d).log 2>&1 & \
+		echo $$! > $(DBLOG_PID_FILE); \
+		echo "DB log capture started (PID: $$!)"; \
+	fi
+
+dblogs-stop:
+	@if [ -f $(DBLOG_PID_FILE) ] && kill -0 $$(cat $(DBLOG_PID_FILE)) 2>/dev/null; then \
+		kill $$(cat $(DBLOG_PID_FILE)) && rm -f $(DBLOG_PID_FILE) && echo "DB log capture stopped"; \
+	else \
+		rm -f $(DBLOG_PID_FILE); \
+		echo "No DB log capture process running"; \
+	fi
+
+dblogs-today:
+	@cat $(DBLOG_DIR)/$$(date +%Y-%m-%d).log 2>/dev/null || echo "No DB logs captured today. Run 'make dblogs-start' first."
+
+dblogs-errors:
+	@grep -i "error\|exception\|fail\|oom\|killed\|exit" $(DBLOG_DIR)/*.log 2>/dev/null || echo "No errors found in captured DB logs"
+
+dblogs-service:
+	@if [ -z "$(SERVICE)" ]; then \
+		echo "Usage: make dblogs-service SERVICE=postgres|elasticsearch"; \
+	else \
+		grep "^$(SERVICE)" $(DBLOG_DIR)/$$(date +%Y-%m-%d).log 2>/dev/null || echo "No logs for $(SERVICE)."; \
+	fi
+
+dblogs-search:
+	@if [ -z "$(PATTERN)" ]; then \
+		echo "Usage: make dblogs-search PATTERN='text'"; \
+	else \
+		grep -i "$(PATTERN)" $(DBLOG_DIR)/*.log 2>/dev/null || echo "Pattern '$(PATTERN)' not found in DB logs"; \
+	fi
+
+dblogs-rotate:
+	@find $(DBLOG_DIR) -name "*.log" -mtime +3 -exec gzip {} \; 2>/dev/null || true
+	@find $(DBLOG_DIR) -name "*.log.gz" -mtime +7 -delete 2>/dev/null || true
+	@echo "DB log rotation complete (compressed >3 days, deleted >7 days)"
+
+dblogs-status:
+	@echo "DB Log directory: $(DBLOG_DIR)"
+	@du -sh $(DBLOG_DIR) 2>/dev/null || echo "No DB logs yet"
+	@echo ""
+	@ls -lh $(DBLOG_DIR)/ 2>/dev/null || echo "No DB log files"
+
+dblogs-clean:
+	@read -p "Delete all captured DB logs? [y/N] " confirm && \
+	[ "$$confirm" = "y" ] && rm -rf $(DBLOG_DIR)/* && echo "DB logs deleted" || echo "Cancelled"
+
+dblogs-cron-install:
+	@DKAPP_DIR=$$(pwd) && \
+	(crontab -l 2>/dev/null | grep -v "dkapp.*dblogs-rotate"; \
+	echo "0 0 * * * cd $$DKAPP_DIR && make dblogs-rotate >> $$DKAPP_DIR/dblogs/cron.log 2>&1") | crontab - && \
+	echo "DB log cron job installed: daily rotation at midnight" && \
+	echo "View with: crontab -l"
+
+dblogs-cron-remove:
+	@crontab -l 2>/dev/null | grep -v "dkapp.*dblogs-rotate" | crontab - && \
+	echo "DB log cron job removed"
+
 prepare:
 	@if [ -f .env.default ]; then \
 		cp .env.default .env; \
@@ -108,8 +182,9 @@ dblogs:
 
 restart: down updb up
 
-down: logs-stop
+down: logs-stop dblogs-stop
 	docker compose -f docker-compose.yml down --remove-orphans
+	docker compose -f db-docker-compose.yml down --remove-orphans
 
 update: down pull build
 	echo "App updated.  Bring it up again with `make updb up logs`"
@@ -168,12 +243,23 @@ pull-latest:
 		python3 docker-pull-retry.py public.ecr.aws/n5k3t9x2/dagknows_nuxt:latest; \
 	fi
 
-updb: dbdirs ensurenetworks
+updb: dbdirs ensurenetworks dblogdirs
 	gpg -o .env -d .env.gpg
 	docker compose -f db-docker-compose.yml down --remove-orphans
 	docker compose -f db-docker-compose.yml up -d
-	sleep 5
+	@echo "Waiting for databases to be healthy..."
+	@echo "  Postgres: checking pg_isready..."
+	@timeout 60 sh -c 'until docker compose -f db-docker-compose.yml exec -T postgres pg_isready -U postgres >/dev/null 2>&1; do sleep 2; done' || \
+		(echo "ERROR: Postgres failed to become ready" && exit 1)
+	@echo "  Postgres: ready"
+	@echo "  Elasticsearch: waiting for cluster status yellow..."
+	@timeout 120 sh -c 'until curl -sf "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s" >/dev/null 2>&1; do sleep 3; done' || \
+		(echo "ERROR: Elasticsearch failed to become ready (possible OOM or startup failure)" && exit 1)
+	@echo "  Elasticsearch: ready"
 	rm -f .env
+	@echo "Starting background database log capture..."
+	@$(MAKE) dblogs-start
+	@echo "Database services are healthy and running."
 
 dbdirs:
 	mkdir -p postgres-data esdata1 elastic_backup
@@ -215,14 +301,16 @@ help:
 	@echo "  make reconfigure  - Update configuration without reinstalling"
 	@echo ""
 	@echo "Service Management:"
-	@echo "  make updb         - Start database services (postgres, elasticsearch)"
+	@echo "  make updb         - Start databases (waits for healthy + auto DB log capture)"
 	@echo "  make up           - Start application services (+ auto log capture)"
-	@echo "  make down         - Stop all services"
+	@echo "  make down         - Stop all services (app + databases + log captures)"
 	@echo "  make restart      - Restart all services"
 	@echo ""
 	@echo "Monitoring:"
 	@echo "  make logs         - View application logs (follow mode)"
 	@echo "  make dblogs       - View database logs (follow mode)"
+	@echo "  make dblogs-today - View today's captured DB logs"
+	@echo "  make dblogs-errors- View DB errors (includes OOM detection)"
 	@echo "  make status       - Check installation status"
 	@echo ""
 	@echo "Log Management:"
@@ -237,6 +325,18 @@ help:
 	@echo "  make logs-clean        - Delete all captured logs"
 	@echo "  make logs-cron-install - Setup daily auto-rotation (cron)"
 	@echo "  make logs-cron-remove  - Remove auto-rotation cron job"
+	@echo ""
+	@echo "Database Log Management:"
+	@echo "  make dblogs-start       - Start background DB log capture"
+	@echo "  make dblogs-stop        - Stop background DB log capture"
+	@echo "  make dblogs-today       - View today's captured DB logs"
+	@echo "  make dblogs-errors      - View DB errors (OOM, killed, etc.)"
+	@echo "  make dblogs-service SERVICE=postgres - View specific DB service"
+	@echo "  make dblogs-search PATTERN='text' - Search DB logs"
+	@echo "  make dblogs-rotate      - Compress old, delete >7 days"
+	@echo "  make dblogs-status      - Show DB log disk usage"
+	@echo "  make dblogs-clean       - Delete all captured DB logs"
+	@echo "  make dblogs-cron-install - Setup daily DB log rotation"
 	@echo ""
 	@echo "Maintenance:"
 	@echo "  make pull         - Pull latest Docker images"

--- a/Makefile
+++ b/Makefile
@@ -358,6 +358,7 @@ help:
 	@echo "  make dblogs-status      - Show DB log disk usage"
 	@echo "  make dblogs-clean       - Delete all captured DB logs"
 	@echo "  make dblogs-cron-install - Setup daily DB log rotation"
+	@echo "  make dblogs-cron-remove  - Remove DB log rotation cron job"
 	@echo ""
 	@echo "Maintenance:"
 	@echo "  make pull         - Pull latest Docker images"

--- a/README.md
+++ b/README.md
@@ -71,13 +71,15 @@ Once installation is complete, you can access DagKnows at the URL you configured
 
 **Useful Commands:**
 ```bash
-make logs        # View application logs
-make dblogs      # View database logs
-make down        # Stop all services
-make up          # Start application services (prompts for password)
-make updb        # Start database services (prompts for password)
-make restart     # Restart all services (prompts for password)
-make pull        # Pull latest Docker images from public ECR
+make logs          # View application logs
+make dblogs        # View database logs (live)
+make dblogs-errors # View database errors (OOM, killed, etc.)
+make down          # Stop all services (app + databases)
+make up            # Start application services (prompts for password)
+make updb          # Start databases (waits for healthy + auto DB log capture)
+make restart       # Restart all services (prompts for password)
+make pull          # Pull latest Docker images from public ECR
+make help          # Show all available commands
 ```
 
 **Note:** Commands that require access to the encrypted `.env` file will prompt for your encryption password (which should be the same as your Super User password if you followed the wizard's recommendation).
@@ -141,9 +143,7 @@ This will prompt for a password and encrypt your `.env` file. Remember this pass
 
 ```bash
 newgrp docker
-make updb dblogs
-# Press Ctrl+C after logs show services are healthy
-
+make updb      # Waits for databases to be healthy + auto-starts DB log capture
 make up logs
 ```
 

--- a/VERSION-MANAGEMENT.md
+++ b/VERSION-MANAGEMENT.md
@@ -217,7 +217,7 @@ After migration, you'll have:
 
 ### Start Application
 ```bash
-# Start databases first
+# Start databases (waits for healthy + auto-starts DB log capture)
 make updb
 
 # Start application services
@@ -227,7 +227,7 @@ make up
 ### Stop Application
 ```bash
 make down
-# This stops BOTH app and database containers
+# This stops BOTH app and database containers + log captures
 ```
 
 ### Restart Application
@@ -245,11 +245,17 @@ make up          # Start app
 
 ### View Logs
 ```bash
-# Follow all logs
+# Follow application logs
 make logs
 
-# View today's captured logs
+# View today's captured app logs
 make logs-today
+
+# View database errors (OOM, killed, etc.)
+make dblogs-errors
+
+# View today's captured DB logs
+make dblogs-today
 ```
 
 ---

--- a/db-docker-compose.yml
+++ b/db-docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   saaslocalnetwork:
     external: true

--- a/db-docker-compose.yml
+++ b/db-docker-compose.yml
@@ -19,6 +19,8 @@ services:
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.9.2
+    ports:
+      - "9200:9200"
     volumes:
       - ./esdata1:/usr/share/elasticsearch/data
       - ./elastic_backup:/opt/elasticsearch/backup

--- a/db-docker-compose.yml
+++ b/db-docker-compose.yml
@@ -38,3 +38,9 @@ services:
       memlock:
         soft: -1
         hard: -1
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf 'http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=10s' || exit 1"]
+      interval: 10s
+      timeout: 15s
+      retries: 12
+      start_period: 30s


### PR DESCRIPTION
Add database observability: ES healthcheck and DB log capture

- Add Elasticsearch healthcheck with wait_for_status=yellow to
  db-docker-compose.yml for proper health monitoring
- Add complete DB log capture system (dblogs-*) mirroring app logs:
  - dblogs-start/stop: Background capture to ./dblogs/
  - dblogs-today/errors: View captured logs and errors (OOM, killed)
  - dblogs-service/search: Filter and search DB logs
  - dblogs-rotate/clean: Log maintenance with cron support
- Update `make updb` to wait for Postgres and ES to be healthy
  before completing, and auto-start DB log capture
- Update `make down` to stop both app and DB services along with
  their respective log captures
- Update help section and LOGGING.md with new commands

This eliminates the need to manually watch `make dblogs` during
startup - updb now blocks until databases are ready.